### PR TITLE
Add srcclr favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" type="text/css" href="assets/reset.css">
     <link rel="stylesheet" type="text/css" href="assets/grid.css">
     <link rel="stylesheet" type="text/css" href="assets/style.css">
+    <link href="https://srcclr.com/favicon.ico" rel="shortcut icon" type="image/x-icon">
     <script type="text/javascript">
 
   var _gaq = _gaq || [];


### PR DESCRIPTION
Currently the favicon on the site still shows twitter logo - 
![screen shot 2015-10-17 at 10 55 15 am](https://cloud.githubusercontent.com/assets/603317/10556712/f59914d4-74bd-11e5-92b4-951f4a813374.png)

This should fix it so that is shows our logo.
